### PR TITLE
New defmojo macro. Syntactic sugar for defining mojos in clojure

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,41 @@ Annotations are used to get values from the pom.
       (SimpleMojo. nil nil nil nil nil (atom nil)))
 ```
 
+For convenience, you may instead use the `defmojo` macro:
+
+```clojure
+    (ns example.simple
+      "Simple Mojo"
+      (:use clojure.maven.mojo.defmojo
+            clojure.maven.mojo.log))
+
+    (defmojo SimpleMojo
+
+      {:goal "simple"
+       :requires-dependency-resolution "test" }
+
+      ;; parameters
+      [base-directory     {:expression "${basedir}" :required true :readonly true}
+
+       classpath-elements {:required true :readonly true
+                           :description "Compile classpath"
+                           :defaultValue "${project.compileClasspathElements}" }
+
+       test-classpath-elements {:required true :readonly true
+                                :defaultValue "${project.testClasspathElements}" } ]
+
+      ;; Body that is executed when Mojo is run
+      (do
+         (info "Hi Maven World!")
+         (info (str "basedir is: " base-directory))))
+```
+
+Note1: `defmojo` implicitly defines params 'log' and 'plugin-context' for you.
+
+Note2: `clojure.maven.mojo.log` defines convenience functions `debug`, `info`, etc.
+for you to send messages to Maven's log stream.
+
+
 ### pom.xml
 
 To write a plugin in clojure, your pom packaging should be set to `maven-plugin`.

--- a/mojo/src/main/clojure/clojure/maven/mojo/defmojo.clj
+++ b/mojo/src/main/clojure/clojure/maven/mojo/defmojo.clj
@@ -1,0 +1,125 @@
+(ns clojure.maven.mojo.defmojo
+  (:require
+   [clojure.string :as str]
+   [clojure.maven.mojo.log :as log])
+  (:import
+   org.apache.maven.plugin.ContextEnabled
+   org.apache.maven.plugin.Mojo
+   org.apache.maven.plugin.MojoExecutionException))
+
+(defn assert-arg [b msg]
+  (if-not b (throw (IllegalArgumentException. msg))
+          b))
+
+(defn validate-param [[param opts]]
+  (assert-arg (and (symbol? param) (map? opts))
+          "Each Mojo parameter must be a symbol followed by a map of options")
+  [param opts])
+
+(fn [[param options]]
+                      (and (symbol? param) (map? options)))
+(defn key->annotation
+  "Convert a keyword name (ie: :requires-dependency) to the
+ corresponding camelcase symbol (ie: RequiresDependency) and
+validate it's a Java annotation"
+  [k]
+  (let [name (str "clojure.maven.annotations."
+                  (-> (name k)
+                      str/capitalize
+                      (str/replace #"-([a-zA-Z])"
+                                   #(str/upper-case (second
+                                                     %)))))
+        fail-msg (str "Cannot find corresponding Mojo annotation for "
+                  k)]
+    (try (assert-arg (.isAnnotation (Class/forName name)) fail-msg)
+         (catch ClassNotFoundException ex
+           (assert-arg false fail-msg)))
+
+    (symbol name)))
+
+
+(defn validate-body [body]
+  (assert-arg (seq body) "Body of your Mojo definition is missing.")
+  (assert-arg (= (count body) 1)
+              (str "Body of your Mojo definition must be a single sexp. "
+                   "You may use form (do ...) to enclose multiple sexps."))
+  body)
+
+
+(defmacro defmojo
+  "Define a Mojo with the given name. This defines some common fields and
+   leaves you to just specify a body for the execute function.
+   Example:
+
+   (defmojo MyClojureMojo
+
+   {:goal \"simple\"
+    :requires-dependency-resolution \"test\"
+    :phase \"validate\" }
+
+    ;; Mojo parameters
+    [base-dir   {:expression \"${basedir}\" :required true :readonly true}
+     project    {:expression \"${project}\" :required true :readonly true}
+     output-dir {:defaultValue \"${project.build.outputDirectory}\"
+                 :required true}]
+
+    (do
+       (println \"Hello Maven World!\")
+       (println \"This is project \" (.getName project))))
+"
+
+  [mojoType annotations-map parameters & body]
+
+  (assert-arg (map? annotations-map)
+              "First arg must be a map of Mojo annotations")
+  (assert-arg (vector? parameters)
+              (str  "Second arg must be a vector of parameters "
+                    "(a name and options map for each param"))
+  (let [mojo-annotations (into {} (map (fn [[k v]] [(key->annotation k) v])
+                                       annotations-map))
+        params (map validate-param (partition-all 2 parameters))
+        ;body (mapcat identity rest)
+        body (validate-body body)]
+
+    `(do
+       (deftype
+           ;; Mojo annotations
+           ~(vary-meta mojoType merge mojo-annotations)
+
+           ;; Mojo parameters
+           ~(vec
+             (concat
+              (map (fn [[param options]]
+                     (vary-meta param merge
+                                {'clojure.maven.annotations.Parameter options}))
+                   params)
+              ;; pre-defined parameters
+              `( ~(with-meta 'log {:volatile-mutable true})
+                 ~'plugin-context
+                 )))
+
+         ;; Mojo predefined methods
+         Mojo
+         ~'(setLog [_ logger] (set! log logger))
+         ~'(getLog [_] log)
+
+         ;; Mojo's suplied methods
+         (~'execute [~'this]
+           (log/with-log ~'log
+             ~@body))
+
+         ;; Plugin-Context handling
+         ContextEnabled
+         ~'(setPluginContext [_ context] (reset! plugin-context context))
+         ~'(getPluginContext [_] @plugin-context)
+         )
+
+
+       (defn ~(symbol (str "make-" mojoType))
+         "Function to provide a no argument constructor"
+         []
+         (~(symbol (str mojoType "."))
+          ~@(repeat (count params) nil) nil (atom nil)))
+
+       )
+    ))

--- a/mojo/src/test/clojure/clojure/maven/mojo/defmojo_test.clj
+++ b/mojo/src/test/clojure/clojure/maven/mojo/defmojo_test.clj
@@ -1,0 +1,143 @@
+(ns clojure.maven.mojo.defmojo-test
+  (:use
+   clojure.test
+   clojure.maven.mojo.defmojo
+   clojure.walk)
+  (:require
+   [clojure.string :as str]
+   [clojure.maven.mojo.log :as log])
+  (:import
+   org.apache.maven.plugin.ContextEnabled
+   org.apache.maven.plugin.Mojo
+   org.apache.maven.plugin.MojoExecutionException))
+
+
+
+(deftest defmacro-minimal
+
+  (is (=
+       (macroexpand-1
+        '(defmojo
+             MyFirstMojo {} [] (log/info "Hello World!")))
+
+       '(do
+          (clojure.core/deftype MyFirstMojo
+            [ ^{:volatile-mutable true} log
+              plugin-context ]
+
+            org.apache.maven.plugin.Mojo
+            (setLog [_ logger] (set! log logger))
+            (getLog [_] log)
+            (execute [this] (clojure.maven.mojo.log/with-log log
+                              (log/info "Hello World!")))
+
+            org.apache.maven.plugin.ContextEnabled
+            (setPluginContext [_ context] (reset! plugin-context context))
+            (getPluginContext [_] (clojure.core/deref plugin-context)))
+
+          (clojure.core/defn make-MyFirstMojo
+            "Function to provide a no argument constructor" []
+            (MyFirstMojo. nil (clojure.core/atom nil)))))))
+
+
+(deftest defmacro-basic
+
+  ;; Note: By definition '=' doesn't compare metadata.
+  ;; Since defmojo generates quite a bit of metadata, we are not really testing
+  ;; all there is to it here :-(
+  (is (=
+       (macroexpand-1
+        '(defmojo
+             MyFirstMojo {:goal "hello-world"}
+             [
+              project {:expression "${project}"}
+              basedir {:expression "${basedir}"}
+              ]
+           (log/info "Hello World!")))
+
+       '(do
+          (clojure.core/deftype ^{clojure.maven.annotations.Goal "hello-world"}
+            MyFirstMojo
+            [^{clojure.maven.annotations.Parameter {:expression "${project}"}}
+             project
+             ^{clojure.maven.annotations.Parameter {:expression "${basedir}"}}
+             basedir
+             ^{:volatile-mutable true}
+             log
+             plugin-context]
+
+            org.apache.maven.plugin.Mojo
+            (setLog [_ logger] (set! log logger))
+            (getLog [_] log)
+
+            (execute [this] (clojure.maven.mojo.log/with-log log
+                              (log/info "Hello World!")))
+
+            org.apache.maven.plugin.ContextEnabled
+            (setPluginContext [_ context] (reset! plugin-context context))
+            (getPluginContext [_] (clojure.core/deref plugin-context)))
+
+          (clojure.core/defn make-MyFirstMojo
+            "Function to provide a no argument constructor" []
+            (MyFirstMojo. nil nil nil (clojure.core/atom nil)))))))
+
+
+
+(deftest body-missing
+  (is (thrown-with-msg? IllegalArgumentException #"Body.*missing"
+        (macroexpand-1 '(defmojo Test {} [])))))
+
+(deftest body-multiple-sexps
+  (is (thrown-with-msg? IllegalArgumentException #"Body.*do"
+        (macroexpand-1 '(defmojo Test {} []
+                          (log/info "first")
+                          (log/info "second"))))))
+
+(deftest invalid-mojo-annotations
+  (is (thrown-with-msg? IllegalArgumentException #"annotation"
+        (macroexpand-1 '(defmojo Test
+                            non-map
+                            []
+                          (log/info "hello world!"))))))
+
+
+(deftest invalid-mojo-annotation
+  (is (thrown-with-msg? IllegalArgumentException #"annotation"
+        (macroexpand-1 '(defmojo Test
+                            {:goalie "test"}
+                            []
+                          (log/info "hello world!"))))))
+
+(deftest invalid-params-vector
+  (is (thrown-with-msg? IllegalArgumentException #"vector.*param"
+        (macroexpand-1 '(defmojo
+                            Test {}
+                            non-vector
+                          (log/info "hello world!"))))))
+
+(deftest invalid-param-pair
+  (is (thrown-with-msg? IllegalArgumentException #"parameter"
+        (macroexpand-1 '(defmojo
+                            Test {}
+                            [param-name]
+                          (log/info "hello world!")))))
+
+  (is (thrown-with-msg? IllegalArgumentException #"parameter"
+        (macroexpand-1 '(defmojo
+                            Test {}
+                            [param-name [:required "true"]]
+                          (log/info "hello world!")))))
+
+  (is (thrown-with-msg? IllegalArgumentException #"parameter"
+        (macroexpand-1 '(defmojo
+                            Test {}
+                            [param-name no-map]
+                          (log/info "hello world!"))))))
+
+(deftest invalid-param-pair
+  (is (thrown-with-msg? IllegalArgumentException #"parameter"
+        (macroexpand-1 '(defmojo
+                            Test
+                            {:goal "test"}
+                            [param-name no-map]
+                          (log/info "hello world!"))))))


### PR DESCRIPTION
Hugo: here's defmojo again. What I've done:
- put defmojo under the new `mojo` artifact
- Write function `keywords->java-annotations`, instead of hardcoded map
- Use `vary-meta`
- Assume body is the body of the execute function
- and also wrap it in `with-log`
- Update example comment and move it to the documentation of `defmojo` definition
- Group mojo parameters in a vector (I thought this was cleaner and also simplified the impl)
- Add validations for better error handling
- Write basic unit tests
- Formatting max 80 columns (the hardest item by far #-), no kidding!)

Additional notes:
- The pom currently don't run unit tests. How can be achieve that? (Could you use zi? Would that be a cyclic dependency?). I use a lein project.clj locally for development.
- Can we think of ways to minimize the number of artifacts that Mojo writers have to depend on?
- Please do send me your feedback. I'm pretty new to Clojure. Writing defmojo was very educational.

Thanks again,
Ferd
