### PR TITLE
Compiling mojos in Windows always throws an "Unsupported escape character"

### DIFF
--- a/mojo-descriptor-extractor/src/main/clojure/clojure/maven/extractor/clojure_mojo_extractor.clj
+++ b/mojo-descriptor-extractor/src/main/clojure/clojure/maven/extractor/clojure_mojo_extractor.clj
@@ -23,6 +23,7 @@
   (symbol (-> file
               (.replaceFirst ".clj$" "")
               (.replaceAll "/" ".")
+              (.replaceAll "\\\\" ".")
               (.replaceAll "_" "-"))))
 
 (defn test-var [v]


### PR DESCRIPTION
file-to-ns-sym fn doesn't work with Windows paths. Replacing '\' with '.'
